### PR TITLE
Run coverage automatically if tests is in interactive session

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,7 +66,7 @@ jobs:
       run: nox --session=coverage
 
     - name: Create xml coverage report
-      run: nox --session=coverage -- xml --fail-under=0
+      run: nox --session=coverage -- xml
 
     - name: Codecov
       uses: codecov/codecov-action@v2.1.0

--- a/noxfile.py
+++ b/noxfile.py
@@ -17,7 +17,11 @@ def tests(session):
     session.install("pytest", "coverage[toml]", "pytest-cov", ".")
     try:
         session.run("coverage", "run", "--parallel", "-m", "pytest", *session.posargs)
+
     finally:
+        # If we're running on an interactive terminal (not CI), run coverage session
+        # so the parallel coverage reports are combined and human-readable output is
+        # printed.
         if session.interactive:
             session.notify("coverage", posargs=[])
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -66,10 +66,10 @@ def coverage(session):
     elif any(Path().glob(".coverage.*")):
         # Combine reports produced in parallel
         session.run("coverage", "combine")
-        args = ["report", "--fail-under=0"]
+        args = ["report"]
 
     else:
-        args = ["report", "--fail-under=0"]
+        args = ["report"]
 
     session.run("coverage", *args)
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -15,7 +15,11 @@ locations = ("src", "tests", "noxfile.py", "docs/conf.py")
 def tests(session):
     """Run test suite for each supported python version."""
     session.install("pytest", "coverage[toml]", "pytest-cov", ".")
-    session.run("coverage", "run", "--parallel", "-m", "pytest", *session.posargs)
+    try:
+        session.run("coverage", "run", "--parallel", "-m", "pytest", *session.posargs)
+    finally:
+        if session.interactive:
+            session.notify("coverage", posargs=[])
 
 
 @session(python=python_versions[0])


### PR DESCRIPTION
Automatically run coverage session if tests is run interactively (as opposed to through CI).  This way, the parallel reports are always combined and we don't fill up the repository with a bunch of junk.

Additionally, allow the coverage report to fail if coverage is under 100%.