### PR TITLE
Use lightly modified release workflow from hypermodern python

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,33 +1,83 @@
+# This is taken almost entirely from the hypermodern python coockiecutter project:
+# https://github.com/cjolowicz/cookiecutter-hypermodern-python-instance/blob/25efb6061a1a653345b5cf10a39eb7dc3db1df48/.github/workflows/release.yml
 name: Release
+
 on:
-  release:
-    types: [published]
+  push:
+    branches:
+      - main
+
 jobs:
   release:
+    name: Release
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3.0.0
+      - name: Check out the repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
 
-    - name: Setup Python
-      uses: actions/setup-python@v3.0.0
-      with:
-        python-version: '3.10'
-        architecture: x64
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.10"
 
-    - name: Install Poetry
-      run: pip install poetry==1.1.13
+      - name: Install Poetry
+        run: |
+          pip install poetry
+          poetry --version
 
-    - name: Install nox and nox-poetry
-      run: |
-        pip install nox==2022.1.7
-        pip install nox-poetry==0.9.0
+      - name: Install nox and nox-poetry
+        run: |
+          pip install nox==2022.1.7
+          pip install nox-poetry==0.9.0
 
-    - name: Run tests and linting
-      run: nox --python=3.10
+      - name: Run tests and linting
+        run: nox --python=3.10
 
-    - name: Build project with poetry
-      run: poetry build
+      - name: Check if there is a parent commit
+        id: check-parent-commit
+        run: |
+          echo "::set-output name=sha::$(git rev-parse --verify --quiet HEAD^)"
 
-    - name: Publish project with poetry
-      run: poetry publish --username=__token__ --password=${{ secrets.PYPI_TOKEN }}
+      - name: Detect and tag new version
+        id: check-version
+        if: steps.check-parent-commit.outputs.sha
+        uses: salsify/action-detect-and-tag-new-version@v2.0.1
+        with:
+          version-command: |
+            bash -o pipefail -c "poetry version | awk '{ print \$2 }'"
+
+      - name: Bump version for developmental release
+        if: "! steps.check-version.outputs.tag"
+        run: |
+          poetry version patch &&
+          version=$(poetry version | awk '{ print $2 }') &&
+          poetry version $version.dev.$(date +%s)
+
+      - name: Build package
+        run: |
+          poetry build --ansi
+
+      - name: Publish package on PyPI
+        if: steps.check-version.outputs.tag
+        uses: pypa/gh-action-pypi-publish@v1.5.0
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_TOKEN }}
+
+      - name: Publish package on TestPyPI
+        if: "! steps.check-version.outputs.tag"
+        uses: pypa/gh-action-pypi-publish@v1.5.0
+        with:
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+
+      - name: Publish the release notes
+        uses: release-drafter/release-drafter@v5.19.0
+        with:
+          publish: ${{ steps.check-version.outputs.tag != '' }}
+          tag: ${{ steps.check-version.outputs.tag }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Use a lightly modified version of the [hypermodern python Release workflow](https://github.com/cjolowicz/cookiecutter-hypermodern-python-instance/blob/25efb6061a1a653345b5cf10a39eb7dc3db1df48/.github/workflows/release.yml).

The main differences are:
- Don't pin pip, poetry versions with a constraints file
- Run tests and linting with nox before release (only with python 3.10), just to be safe