### PR TITLE
Don't run tests as part of release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,14 +27,6 @@ jobs:
           pip install poetry
           poetry --version
 
-      - name: Install nox and nox-poetry
-        run: |
-          pip install nox==2022.1.7
-          pip install nox-poetry==0.9.0
-
-      - name: Run tests and linting
-        run: nox --python=3.10
-
       - name: Check if there is a parent commit
         id: check-parent-commit
         run: |


### PR DESCRIPTION
In the Release workflow, I was running some tests through `nox` as a final check before uploading anything.  However, `nox-poetry` builds the package so that it can install the wheel and pin versions against the lockfile.  This meant that `dist/` contained a wheel built with the un-bumped version number, and this was being uploaded to TestPyPI.

The [hypermodern python Release workflow](https://github.com/cjolowicz/cookiecutter-hypermodern-python-instance/blob/beea0fc799eac9779af5ebf62ef45fa6f799d7f7/.github/workflows/release.yml) simply doesn't run tests, so we will copy this behavior.