### PR TITLE
Fix bug in WordleGuesses.wordle_letters

### DIFF
--- a/src/wordle_cheater/cheater.py
+++ b/src/wordle_cheater/cheater.py
@@ -1,4 +1,5 @@
 """Utilities for generating solutions to Wordle given previous guesses."""
+from copy import deepcopy
 from dataclasses import dataclass
 
 from wordle_cheater.dictionary import letters, wordle_dictionary
@@ -112,7 +113,7 @@ class WordleGuesses:
         if wordle_letters is None:
             wordle_letters = []
 
-        self.wordle_letters = wordle_letters.copy()
+        self.wordle_letters = []
         self.blacks = [[], [], [], [], []]
         self.yellows = [[], [], [], [], []]
         self.greens = [None, None, None, None, None]
@@ -167,7 +168,7 @@ class WordleGuesses:
             raise InvalidWordleLetters(exc_str, invalid_letters)
 
         # If we made it this far, update current list of letters
-        self.wordle_letters += word
+        self.wordle_letters += deepcopy(word)
 
         # Add the word to self.blacks, self.yellows, self.greens, self.counts
         these_counts = dict()  # colored letters in this word and their counts

--- a/tests/test_cheater.py
+++ b/tests/test_cheater.py
@@ -108,3 +108,10 @@ def test_easy_cheat():
     """Test the easy_cheat convenience function."""
     solutions = easy_cheat("beats oiled", "bybbb bbygy")
     assert sorted(solutions) == sorted(["elder", "dynel"])
+
+
+def test_wordle_guesses_letters():
+    """WordleGuesses.wordle_letters is set appropriately."""
+    wordle_letters = get_wordle_letters("beats", "bybbb")
+    guesses = WordleGuesses(wordle_letters)
+    assert guesses.wordle_letters == wordle_letters


### PR DESCRIPTION
When initializing a `WordleGuesses` object, the initial letters were added twice to the `WordleGuesses.wordle_letters` attribute.  In addition, they were a shallow copy, which could potentially cause issues down the line.

This PR fixes the double addition of words to the `wordle_letters` attribute, and ensures that they are a deep copy of the original objects.